### PR TITLE
php5-dev is required for php::extension

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ To ensure that things happen in a predictable order please use the example below
 
 ```
 # Install extensions; Configure extensions; Reload apache if changed
-Php::Extension <| |> -> Php::Config <| |> ~> Service["apache2"]
+Package['php5-dev'] -> Php::Extension <| |> -> Php::Config <| |> ~> Service["apache2"]
 ```
 
 If you rely on `dotdeb` you also want to make sure that the `php::apt` class is loaded and `apt` has been updated (`apt-get update`) before packages are installed


### PR DESCRIPTION
php5-dev is required for the pecl provider (most of the time).

If binaries of an extension aren't available, pecl compiles from source, though in some cases, php::extension gets evaluated after php5-dev has been installed, causing pecl to silently fail and only install the extension on 2nd run of puppet.
