### PR TITLE
Add version to dependencies in Modulefile.

### DIFF
--- a/Modulefile
+++ b/Modulefile
@@ -6,5 +6,5 @@ summary 'Puppet module to manage PHP on debian / ubuntu - easily expandable to s
 description 'Puppet module to manage PHP on debian / ubuntu - easily expandable to support other platforms'
 project_page 'https://github.com/jippi/puppet-php'
 
-dependency 'puppetlabs/stdlib'
-dependency 'puppetlabs/apt'
+dependency 'puppetlabs/stdlib', '> 0.0.0'
+dependency 'puppetlabs/apt', '> 0.0.0'


### PR DESCRIPTION
Fixes issue when using librarian-puppet. If you try and use a git clone instead of the puppet forge version, it errors in librarian-puppet if there is no version in the Modulefile's dependencies.
