### PR TITLE
Add wheezy repository for dotdeb if wheezy-php55 is used.

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -38,6 +38,17 @@ class php::apt(
   }
 
   if ($dotdeb) {
+    # wheezy-php55 requires both repositories to work correctly
+    # See: http://www.dotdeb.org/instructions/
+    if $release == 'wheezy-php55' {
+      apt::source { 'dotdeb-wheezy':
+        location    => $location,
+        release     => 'wheezy',
+        repos       => $repos,
+        include_src => $include_src
+      }
+    }
+
     exec { 'add_dotdeb_key':
       command =>
         'curl --silent "http://www.dotdeb.org/dotdeb.gpg" | apt-key add -',


### PR DESCRIPTION
Ran into an issue installing the php5-memcached extension because it couldn't find libmemcache11. It's located in the wheezy version and the documentation on using dotdeb packages says that both repos need to be added to apt sources.
