### PR TITLE
Added optional provider defaults to base_backage and extension classes

### DIFF
--- a/manifests/contrib/base_package.pp
+++ b/manifests/contrib/base_package.pp
@@ -5,10 +5,12 @@
 # === Parameters
 #
 # [*ensure*]
-#   The ensure value
+#   The ensure of the package to install
+#   Could be "latest", "installed" or a pinned version
 #
 # [*provider*]
-#   The provider
+#   The provider used to install the package
+#   Could be "pecl", "apt", "dpkg" or any other OS package provider
 #
 # === Variables
 #
@@ -26,7 +28,10 @@
 #
 #
 #
-define php::contrib::base_package($ensure, $provider) {
+define php::contrib::base_package(
+  $ensure,
+  $provider = undef
+) {
 
   if !defined(Package['php5-common']) {
     package { 'php5-common':

--- a/manifests/extension.pp
+++ b/manifests/extension.pp
@@ -60,9 +60,9 @@
 define php::extension(
   $ensure,
   $package,
-  $provider,
-  $pipe = undef,
-  $source = undef
+  $provider = undef,
+  $pipe     = undef,
+  $source   = undef
 ) {
 
   if $provider == 'pecl' {


### PR DESCRIPTION
Well, I'm not exactly sure why PR #27 seemed to end up deleting all of the code from your branch, but just in case you need this again, I'm creating a PR based off of an actual feature branch instead of my production branch.  I'm using branches named `production` for my own internal use and they aren't guaranteed to be compatible with the master. 
#### Commit Message:

Not having `undef` as a default provider was causing errors similar to:

```
err: Could not retrieve catalog from remote server: Error 400 on SERVER:
Must pass provider to Php::Contrib::Base_package[cli]
```

Making the extension and php::contrib::base_package defines use `undef`
as a default still allows provider selection while falling back to sane
puppet defaults.
