### PR TITLE
When installing PEAR package, install all dependencies

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -84,7 +84,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
   end
 
   def install(useversion = true)
-    command = ["upgrade"]
+    command = ["upgrade", "-a"]
 
     if source = @resource[:source]
       command << source


### PR DESCRIPTION
When installing PEAR packages the dependencies were not installed. Maybe I missed some required setup. This should fix the problem.
