### PR TITLE
Speed up Augeas resources by specifying the lens.

### DIFF
--- a/manifests/augeas.pp
+++ b/manifests/augeas.pp
@@ -28,8 +28,8 @@
 #
 class php::augeas {
 
-  if !defined(File['/usr/share/augeas/lenses/contrib']) {
-    file { '/usr/share/augeas/lenses/contrib':
+  if !defined(File[$php::params::augeas_contrib_dir]) {
+    file { $php::params::augeas_contrib_dir:
       ensure  => directory,
       recurse => true,
       purge   => true,
@@ -40,10 +40,10 @@ class php::augeas {
     }
   }
 
-  file { '/usr/share/augeas/lenses/contrib/php.aug':
+  file { "${php::params::augeas_contrib_dir}/php.aug":
     ensure  => present,
     source  => 'puppet:///modules/php/php.aug',
-    require => File['/usr/share/augeas/lenses/contrib']
+    require => File[$php::params::augeas_contrib_dir]
   }
 
 }

--- a/manifests/config.pp
+++ b/manifests/config.pp
@@ -41,8 +41,9 @@ define php::config(
   include php::augeas
 
   augeas { "php-${name}-config":
-    context   => "/files${inifile}",
-    load_path => '/usr/share/augeas/lenses/contrib/',
+    incl      => $inifile,
+    lens      => 'PHP.lns',
+    load_path => $php::params::augeas_contrib_dir,
     changes   => template('php/augeas_commands.erb'),
     require   => Class['php::augeas']
   }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,4 +29,6 @@ class php::params {
 
   $ensure = 'installed'
 
+  $augeas_contrib_dir = '/usr/share/augeas/lenses/contrib'
+
 }


### PR DESCRIPTION
Augeas resources are extremely slow when using a context instead of
a specific lens because Augeas has to compile all of the lenses to
decide which lens to use. If the lens needed is already known,
it should be specified.

On an Ubuntu 12.04 box, Augeas usage per resource went from ~.55s
to .01s when measured using puppet-profiler.

This change also introduces a new php::params variable
$augeas_contrib_dir. The Augeas contrib dir was being repeated five
times in two separate files.
