### PR TITLE
fix ext-apcu default config

### DIFF
--- a/manifests/extension/apcu/params.pp
+++ b/manifests/extension/apcu/params.pp
@@ -44,5 +44,7 @@ class php::extension::apcu::params {
   $package  = 'php5-apcu'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/apcu.ini"
-  $settings = []
+  $settings = {
+    set => {}
+  }
 }


### PR DESCRIPTION
Fixes:

err: Could not retrieve catalog from remote server: Error 400 on SERVER: Failed to parse template php/augeas_commands.erb:
  Filepath: /etc/puppet/modules/php/templates/augeas_commands.erb
  Line: 1
  Detail: can't convert String into Integer
