### PR TITLE
Update to regex in pecl.rb and pear.rb

### DIFF
--- a/lib/puppet/provider/package/pear.rb
+++ b/lib/puppet/provider/package/pear.rb
@@ -63,7 +63,7 @@ Puppet::Type.type(:package).provide :pear, :parent => Puppet::Provider::Package 
       when /no packages installed/i then return nil
       when /^=/ then return nil
       when /^PACKAGE/i then return nil
-      when /^(\S+)\s+([.\d]+)\s+(\S+)\s*$/ then
+      when /^(\S+)\s+(\S+)\s+(\S+)\s*$/ then
         name = $1
         version = $2
         state = $3

--- a/lib/puppet/provider/package/pecl.rb
+++ b/lib/puppet/provider/package/pecl.rb
@@ -59,7 +59,7 @@ Puppet::Type.type(:package).provide :pecl, :parent => Puppet::Provider::Package 
     when /No packages installed from channel/i then return nil
     when /^=/ then return nil
     when /^PACKAGE/ then return nil
-    when /^(\S+)\s+([.\d]+)\s+\S+/ then
+    when /^(\S+)\s+(\S+)\s+\S+/ then
       name = $1
       version = $2
 


### PR DESCRIPTION
Got bit by the problem in this note: https://github.com/jippi/puppet-php/issues/39  

Tested in our local environment and it resolves the issue of RC package versions not getting matched.
