### PR TITLE
Adding PECL MongoDB extension

### DIFF
--- a/manifests/extension/mongo.pp
+++ b/manifests/extension/mongo.pp
@@ -1,0 +1,64 @@
+# == Class: php::extension::mongo
+#
+# Install the PHP mongo extension
+#
+# === Parameters
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Variables
+#
+# No variables
+#
+# === Examples
+#
+#  include 'php::extension::mongo'
+#
+#  class {'php::extension::mongo':
+#   ensure => latest
+#  }
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+# Davide "SbiellONE" Bellettini <davide@bellettini.me>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::mongo(
+  $ensure   = $php::extension::mongo::params::ensure,
+  $package  = $php::extension::mongo::params::package,
+  $provider = $php::extension::mongo::params::provider,
+  $inifile  = $php::extension::mongo::params::inifile,
+  $settings = $php::extension::mongo::params::settings
+) inherits php::extension::mongo::params {
+
+  php::extension { 'mongo':
+    ensure   => $ensure,
+    package  => $package,
+    provider => $provider
+  }
+
+  php::config { 'php-extension-mongo':
+    file    => $inifile,
+    config  => $settings
+  }
+}

--- a/manifests/extension/mongo/params.pp
+++ b/manifests/extension/mongo/params.pp
@@ -1,0 +1,52 @@
+# == Class: php::extension::mongo::params
+#
+# Defaults file for the mongo PHP extension
+#
+# === Parameters
+#
+# No parameters
+#
+# === Variables
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Examples
+#
+# No examples
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+# Davide "SbiellONE" Bellettini <davide@bellettini.me>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::mongo::params {
+
+  $ensure   = $php::params::ensure
+  $package  = 'mongo'
+  $provider = 'pecl'
+  $inifile  = "${php::params::config_root_ini}/mongo.ini"
+  $settings = [
+    'set ".anon/extension" "mongo.so"'
+  ]
+
+}


### PR DESCRIPTION
MongoDB extension is available through PECL only (in Ubuntu)
