### PR TITLE
Added 'ondemand' support for the PHP-FPM process manager.

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -32,6 +32,7 @@ define php::fpm::pool (
   $pm_min_spare_servers = '5',
   $pm_max_spare_servers = '35',
   $pm_max_requests = '0',
+  $pm_process_idle_timeout = '10s',
   $pm_status_path = undef,
   $ping_path = undef,
   $ping_response = 'pong',

--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -59,16 +59,23 @@ group = <%= @group_final %>
 ;                                    state (waiting to process). If the number
 ;                                    of 'idle' processes is greater than this
 ;                                    number then some children will be killed.
+;  ondemand - no children are created at startup. Children will be forked when
+;             new requests will connect. The following parameter are used:
+;             pm.max_children           - the maximum number of children that
+;                                         can be alive at the same time.
+;             pm.process_idle_timeout   - The number of seconds after which
+;                                         an idle process will be killed.
 ; Note: This value is mandatory.
 pm = <%= @pm %>
 
 ; The number of child processes to be created when pm is set to 'static' and the
-; maximum number of child processes to be created when pm is set to 'dynamic'.
+; maximum number of child processes when pm is set to 'dynamic' or 'ondemand'.
 ; This value sets the limit on the number of simultaneous requests that will be
 ; served. Equivalent to the ApacheMaxClients directive with mpm_prefork.
 ; Equivalent to the PHP_FCGI_CHILDREN environment variable in the original PHP
-; CGI.
-; Note: Used when pm is set to either 'static' or 'dynamic'
+; CGI. The below defaults are based on a server without much resources. Don't
+; forget to tweak pm.* to fit your needs.
+; Note: Used when pm is set to 'static', 'dynamic' or 'ondemand'
 ; Note: This value is mandatory.
 pm.max_children = <%= @pm_max_children %>
 
@@ -87,6 +94,11 @@ pm.min_spare_servers = <%= @pm_min_spare_servers %>
 ; Note: Mandatory when pm is set to 'dynamic'
 pm.max_spare_servers = <%= @pm_max_spare_servers %>
 
+; The number of seconds after which an idle process will be killed.
+; Note: Used only when pm is set to 'ondemand'
+; Default Value: 10s
+pm.process_idle_timeout = <%= @pm_process_idle_timeout %>
+
 ; The number of requests each child process should execute before respawning.
 ; This can be useful to work around memory leaks in 3rd party libraries. For
 ; endless request processing specify '0'. Equivalent to PHP_FCGI_MAX_REQUESTS.
@@ -98,7 +110,7 @@ pm.max_requests = <%= @pm_max_requests %>
 ; information:
 ;   accepted conn    - the number of request accepted by the pool;
 ;   pool             - the name of the pool;
-;   process manager  - static or dynamic;
+;   process manager  - static, dynamic or ondemand;
 ;   idle processes   - the number of idle processes;
 ;   active processes - the number of active processes;
 ;   total processes  - the number of idle + active processes.


### PR DESCRIPTION
The current FPM pool configuration doesn't support the `pm.process_idle_timeout` setting which is needed if you use 'ondemand'.
