### PR TITLE
Since php 5.4 the location of ini files has changed. Therefore all instanciations of php extensions will have to propertly set the ini file parameter, when running php < 5.4

### DIFF
--- a/lib/facter/php_version.rb
+++ b/lib/facter/php_version.rb
@@ -1,7 +1,7 @@
 Facter.add(:php_version) do
   confine :kernel => :linux
   setcode do
-    version = Facter::Util::Resolution.exec("/usr/bin/php --version | grep '^PHP ' | awk '{print $2}'")
+    version = Facter::Util::Resolution.exec("/usr/bin/env php -r 'echo PHP_VERSION;'")
     if version
       version.match(/(\d+\.\d+\.\d+)/).to_s
     else

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -31,7 +31,7 @@ class php::params {
 
   $config_root = '/etc/php5'
 
-  if versioncmp($::php_version, '5.4') >= 0 {
+  if $::php_version == '' or versioncmp($::php_version, '5.4') >= 0 {
     $config_root_ini = "${::php::params::config_root}/mods-available"
   } else {
     $config_root_ini = "${::php::params::config_root}/conf.d"

--- a/spec/classes/xdebug_spec.rb
+++ b/spec/classes/xdebug_spec.rb
@@ -5,7 +5,17 @@ describe 'php::extension::xdebug' do
     'include "php"'
   end
 
-  context 'php 5.3' do
+  context 'with an undetermined php version' do
+    let(:facts) { { :php_version => '' } }
+
+    it { should contain_augeas("php-php-extension-xdebug-config")
+      .with({
+        :incl      => '/etc/php5/mods-available/xdebug.ini',
+      })
+    }
+  end
+
+  context 'with php 5.3' do
     let(:facts) { { :php_version => '5.3'} }
 
     it { should contain_augeas("php-php-extension-xdebug-config")
@@ -15,7 +25,7 @@ describe 'php::extension::xdebug' do
     }
   end
 
-  context 'php 5.4' do
+  context 'with php 5.4' do
     let(:facts) { { :php_version => '5.4'} }
 
     it { should contain_augeas("php-php-extension-xdebug-config")
@@ -25,7 +35,7 @@ describe 'php::extension::xdebug' do
     }
   end
 
-  context 'php 5.4.1' do
+  context 'with php 5.4.1' do
     let(:facts) { { :php_version => '5.4.1'} }
 
     it { should contain_augeas("php-php-extension-xdebug-config")
@@ -35,7 +45,7 @@ describe 'php::extension::xdebug' do
     }
   end
 
-  context 'php 5.5' do
+  context 'with php 5.5' do
     let(:facts) { { :php_version => '5.5'} }
 
     it { should contain_augeas("php-php-extension-xdebug-config")
@@ -44,4 +54,15 @@ describe 'php::extension::xdebug' do
       })
     }
   end
+  
+  context 'with php 5.5.11-1~dotdeb.1' do
+    let(:facts) { { :php_version => '5.5'} }
+
+    it { should contain_augeas("php-php-extension-xdebug-config")
+      .with({
+        :incl      => '/etc/php5/mods-available/xdebug.ini',
+      })
+    }
+  end
+  
 end


### PR DESCRIPTION
Added a fact that determines the installed php version and lets the php::params class set the config_root_ini parameter accordingly.
