### PR TITLE
fixed parameter typo.

### DIFF
--- a/manifests/apache/config.pp
+++ b/manifests/apache/config.pp
@@ -45,7 +45,7 @@ define php::apache::config(
     setting => $setting,
     value   => $value,
     notify  => Service[$php::apache::params::service_name],
-    souce   => 'apache',
+    source  => 'apache',
   }
 
 }


### PR DESCRIPTION
Hello,

Fixes the typo when using `php::apache::config`.
