### PR TITLE
change service name for compatibility with puppetlabs-apache

### DIFF
--- a/manifests/apache.pp
+++ b/manifests/apache.pp
@@ -63,10 +63,4 @@ class php::apache(
     config  => $settings
   }
 
-  service { 'httpd':
-    ensure => running,
-    enable => true,
-    name   => $service_name,
-  }
-
 }

--- a/manifests/apache/config.pp
+++ b/manifests/apache/config.pp
@@ -27,12 +27,13 @@
 # Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
 #
 define php::apache::config(
-  $ensure   = 'present',
-  $file     = $php::apache::params::inifile,
-  $config   = undef,
-  $setting  = undef,
-  $section  = 'PHP',
-  $value    = undef,
+  $ensure       = 'present',
+  $file         = $php::apache::params::inifile,
+  $config       = undef,
+  $setting      = undef,
+  $section      = 'PHP',
+  $service_name = $php::apache::params::service_name,
+  $value        = undef,
 ) {
 
   include ::php::apache::params
@@ -44,7 +45,7 @@ define php::apache::config(
     section => $section,
     setting => $setting,
     value   => $value,
-    notify  => Service['httpd'],
+    notify  => Service[$service_name],
     source  => 'apache',
   }
 


### PR DESCRIPTION
Hello,

When writing tests for another module that uses this and puppetlabs-apache I get:

```
     Failure/Error: it { should compile.with_all_deps }
       expected that the catalogue would include Service[apache2] used at /Users/stephenh/Vagrant/vagrant-zabbix/puppet/modules/zabbix/spec/fixtures/modules/php/manifests/apache/config.pp:49 in Php::Config[upload_max_filesize=2M]
```

To fix this I've added a 'httpd' service to php::apache and reference this in php::apache::config.

So far this seems to work fine; the test no longer fails and the same notification takes place if including php::apache when puppetlabs-apache isn't present.
