### PR TITLE
Silence php_version fact if no PHP is installed

### DIFF
--- a/lib/facter/php_version.rb
+++ b/lib/facter/php_version.rb
@@ -1,7 +1,7 @@
 Facter.add(:php_version) do
   confine :kernel => :linux
   setcode do
-    version = Facter::Util::Resolution.exec("/usr/bin/env php -r 'echo PHP_VERSION;'")
+    version = Facter::Util::Resolution.exec("/usr/bin/env php -r 'echo PHP_VERSION;' 2>/dev/null")
     if version
       version.match(/(\d+\.\d+\.\d+)/).to_s
     else


### PR DESCRIPTION
Redirect stderr to /dev/null, thereby keeping the Puppet agent run quiet on nodes where no PHP is installed.
