### PR TITLE
Update mongo.pp

### DIFF
--- a/manifests/extension/mongo.pp
+++ b/manifests/extension/mongo.pp
@@ -61,4 +61,11 @@ class php::extension::mongo(
     file    => $inifile,
     config  => $settings
   }
+  
+  if $::php_version == '' or versioncmp($::php_version, '5.4') >= 0 {
+    file { "${::php::params::config_root}/conf.d/20-mongo.ini" :
+      ensure => link,
+      target => "${::php::params::config_root_ini}/mongo.ini"
+    }
+  }
 }

--- a/manifests/extension/mongo.pp
+++ b/manifests/extension/mongo.pp
@@ -65,7 +65,11 @@ class php::extension::mongo(
   if $::php_version == '' or versioncmp($::php_version, '5.4') >= 0 {
     file { "${::php::params::config_root}/conf.d/20-mongo.ini" :
       ensure => link,
-      target => "${::php::params::config_root_ini}/mongo.ini"
+      target => "${::php::params::config_root_ini}/mongo.ini",
+      require => [
+        Php::Extension['mongo'],
+        Php::Config['php-extension-mongo']
+      ]
     }
   }
 }


### PR DESCRIPTION
By default, Mongo extension is not installed in "conf.d" with PHP 5.4. 
The "mongo.ini" is only in "mods-availaible"
