### PR TITLE
Adding "Mailparse" extension

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -126,6 +126,23 @@ Class name: ``php::extension::ldap``.
 
 * ``$inifile`` defaults to ``${php::params::config_root_ini}/ldap.ini``
 
+mailparse
+--------
+
+.. note::
+
+  The package requires the ``build-essential`` and ``php5-dev`` system packages.
+
+Class name: ``php::extension::mailparse``.
+
+* ``$package`` defaults to ``mailparse``
+
+* ``$provider`` defaults to ``pecl``
+
+* ``$inifile`` defaults to ``${php::params::config_root_ini}/mailparse.ini``
+
+* ``$settings`` defaults to ``['set ".anon/extension" "mailparse.so"']``
+
 mcrypt
 ------
 

--- a/manifests/extension/mailparse.pp
+++ b/manifests/extension/mailparse.pp
@@ -1,0 +1,60 @@
+# == Class: php::extension::mailparse
+#
+# Install and configure the mailparse PHP extension
+#
+# === Parameters
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Variables
+#
+# No variables
+#
+# === Examples
+#
+#  include php::extension::mailparse
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::mailparse(
+  $ensure   = $php::extension::mailparse::params::ensure,
+  $package  = $php::extension::mailparse::params::package,
+  $provider = $php::extension::mailparse::params::provider,
+  $inifile  = $php::extension::mailparse::params::inifile,
+  $settings = $php::extension::mailparse::params::settings
+) inherits php::extension::mailparse::params {
+
+  php::extension { 'mailparse':
+    ensure   => $ensure,
+    package  => $package,
+    provider => $provider
+  }
+
+  php::config { 'php-extension-mailparse':
+    file    => $inifile,
+    config  => $settings
+  }
+
+}

--- a/manifests/extension/mailparse/params.pp
+++ b/manifests/extension/mailparse/params.pp
@@ -1,0 +1,51 @@
+# == Class: php::extension::mailparse::params
+#
+# Defaults file for the mailparse PHP extension
+#
+# === Parameters
+#
+# No parameters
+#
+# === Variables
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Examples
+#
+# No examples
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::mailparse::params {
+
+  $ensure   = $php::params::ensure
+  $package  = 'mailparse'
+  $provider = 'pecl'
+  $inifile  = "${php::params::config_root_ini}/mailparse.ini"
+  $settings = [
+    'set ".anon/extension" "mailparse.so"'
+  ]
+
+}


### PR DESCRIPTION
Hello,

This should add the ability to use the "mailparse" extension.
I tested it on Ubuntu 14.04 with PHP5.5.9.

I do have an issue: I have to use `/usr/sbin/php5enmod mail parse` to see the mailparse module listed in when doing a `php -m`
I'm not entirely sure if that's meant to be, so any guidance is welcome!
