### PR TITLE
Added extension oauth

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -192,6 +192,15 @@ Class name: ``php::extension::newrelic``.
 
 * ``$inifile`` defaults to ``${php::params::config_root_ini}/newrelic.ini``
 
+oauth
+-----
+
+Class name: ``php::extension::oauth``.
+
+* ``$package`` defaults to ``php5-oauth``
+
+* ``$inifile`` defaults to ``${php::params::config_root_ini}/oauth.ini``
+
 opcache
 -------
 

--- a/manifests/extension/oauth.pp
+++ b/manifests/extension/oauth.pp
@@ -1,0 +1,60 @@
+# == Class: php::extension::oauth
+#
+# Install and configure the oauth PHP extension
+#
+# === Parameters
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Variables
+#
+# No variables
+#
+# === Examples
+#
+#  include php::extension::oauth
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::oauth(
+  $ensure   = $php::extension::oauth::params::ensure,
+  $package  = $php::extension::oauth::params::package,
+  $provider = $php::extension::oauth::params::provider,
+  $inifile  = $php::extension::oauth::params::inifile,
+  $settings = $php::extension::oauth::params::settings,
+) inherits php::extension::oauth::params {
+
+  php::extension { 'oauth':
+    ensure   => $ensure,
+    package  => $package,
+    provider => $provider
+  }
+
+  php::config { 'php-extension-oauth':
+    file    => $inifile,
+    config  => $settings
+  }
+
+}

--- a/manifests/extension/oauth/params.pp
+++ b/manifests/extension/oauth/params.pp
@@ -1,0 +1,49 @@
+# == Class: php::extension::oauth::params
+#
+# Defaults file for the oauth PHP extension
+#
+# === Parameters
+#
+# No parameters
+#
+# === Variables
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Examples
+#
+# No examples
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::oauth::params {
+
+  $ensure   = $php::params::ensure
+  $package  = 'php5-oauth'
+  $provider = undef
+  $inifile  = "${php::params::config_root_ini}/oauth.ini"
+  $settings = [ ]
+
+}


### PR DESCRIPTION
Hi,

This should add the ability to use the "oauth" extension.
I tested it on Ubuntu 14.04 with PHP5.5.9.

Same as  #84, I need to use /usr/sbin/php5enmod to load the module.
