### PR TITLE
Fix pecl latest() - String is no longer Enumberable in Ruby 1.9

### DIFF
--- a/lib/puppet/provider/package/pecl.rb
+++ b/lib/puppet/provider/package/pecl.rb
@@ -103,7 +103,7 @@ Puppet::Type.type(:package).provide :pecl, :parent => Puppet::Provider::Package 
   def latest
     version = ''
     command = [command(:pearcmd), "remote-info", "#{@resource[:name]}"]
-      list = execute(command).collect do |set|
+      list = execute(command).lines.collect do |set|
       if set =~ /^Latest/
         version = set.split[1]
       end


### PR DESCRIPTION
Fix works on both new/old versions of ruby
