### PR TITLE
fpm config depends on fpm package

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -53,7 +53,8 @@ class php::fpm(
 
   php::fpm::config { 'php-fpm':
     file    => $inifile,
-    config  => $settings
+    config  => $settings,
+    require => Package[$package]
   }
 
 }


### PR DESCRIPTION
This fixes an error, that only occurs on unprovisioned (ubuntu) systems:
Puppet tried to configure fpm before the package was installed, so augeas tried to write a file to a directory, that does not exist an this time and throw an error.
