### PR TITLE
Fixed issue with the pool.conf.erb template:

### DIFF
--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -269,7 +269,7 @@ env[<%= key %>] = <%= value %>
 ;
 
 <% @php_value.sort_by {|key,value| key}.each do |key,value| -%>
-<%= key -%> = <%= value %>
+php_value[<%= key -%>] = <%= value %>
 <% end -%>
 
 ;
@@ -285,7 +285,7 @@ php_flag[<%= key -%>] = <%= flag %>
 ;
 
 <% @php_admin_value.sort_by {|key,value| key}.each do |key,value| -%>
-<%= key -%> = <%= value %>
+php_admin_value[<%= key -%>] = <%= value %>
 <% end -%>
 
 ;
@@ -293,7 +293,7 @@ php_flag[<%= key -%>] = <%= flag %>
 ;
 
 <% @php_admin_flag.sort_by {|key,flag| key}.each do |key,flag| -%>
-<%= key -%> = <%= flag %>
+php_admin_flag[<%= key -%>] = <%= flag %>
 <% end -%>
 
 ;


### PR DESCRIPTION
Custom php values, admin values and admin flags where not written correctly.

This allows to define php_value, php_admin_value and php_admin_flag in the same way php_flag is defined.
