### PR TITLE
Default to empty hash in FPM example, not empty array

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -78,7 +78,7 @@ FPM
     }
 
     create_resources('php::fpm::pool',  hiera_hash('php_fpm_pool', {}))
-    create_resources('php::fpm::config',  hiera_hash('php_fpm_config', []))
+    create_resources('php::fpm::config',  hiera_hash('php_fpm_config', {}))
 
     Php::Extension <| |> ~> Service['php5-fpm']
 


### PR DESCRIPTION
In the FPM example, an empty array is used as a default value for the hiera hash 'php_fpm_config'. This should be an empty hash instead.
