### PR TITLE
Assure that xdebug extension is installed before changing xdebug.ini

### DIFF
--- a/manifests/extension/xdebug.pp
+++ b/manifests/extension/xdebug.pp
@@ -51,10 +51,10 @@ class php::extension::xdebug (
     package  => $package,
     provider => $provider
   }
-
+  ->
   php::config { 'php-extension-xdebug':
-    file    => $inifile,
-    config  => $settings
+    file   => $inifile,
+    config => $settings
   }
 
 }


### PR DESCRIPTION
I encountered most likely an edge case in which changes to the xdebug configuration file would be applied before the the extension is installed.
