### PR TITLE
add config_mode Property to php::fpm::pool

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -54,7 +54,8 @@ define php::fpm::pool (
   $php_admin_flag = {},
   $php_directives = [],
   $log_errors = true,
-  $error_log = true
+  $error_log = true,
+  $config_mode = '0644',
 ) {
 
   $pool = $title
@@ -75,7 +76,7 @@ define php::fpm::pool (
       content => template('php/fpm/pool.conf.erb'),
       owner   => root,
       group   => root,
-      mode    => '0644'
+      mode    => $config_mode,
     }
   }
 


### PR DESCRIPTION
We use global Variables to supply sensitive Informations such as Database Logins to the PHP Applications. Those Variables are defined trough the env_value Parameter of the FPM Pool. We do not want those Configurations readable for all by default, therefore we need a way to alter the mode of the Pool Configuration File.
