### PR TITLE
[#106] Fix wrong inifile setting for xcache extension.

### DIFF
--- a/manifests/extension/xcache/params.pp
+++ b/manifests/extension/xcache/params.pp
@@ -43,7 +43,7 @@ class php::extension::xcache::params {
   $ensure   = $php::params::ensure
   $package  = 'php5-xcache'
   $provider = undef
-  $inifile  = '/etc/php5/conf.d/20-xcache.ini'
+  $inifile  = "${php::params::config_root_ini}/xcache.ini"
   $settings = []
 
 }


### PR DESCRIPTION
``` bash
==> default: Error: /Stage[main]/[...]: Could not evaluate: Save failed with return code false, see debug
```

The error occurs if you try to set settings for xcache extension.

Actual: `$inifile = '/etc/php5/conf.d/20-xcache.ini'`
Should be: `$inifile = "${php::params::config_root_ini}/xcache.ini"`

This PR fixes this issue (#106).
