### PR TITLE
deprecated php::fpm::daemon and move php-fpm.conf settings into php::fpm

### DIFF
--- a/docs/examples.rst
+++ b/docs/examples.rst
@@ -74,7 +74,11 @@ FPM
     include php::params
 
     class { 'php::fpm':
-      ensure => $version
+      ensure => $version,
+      emergency_restart_threshold  => 5,
+      emergency_restart_interval   => '1m',
+      rlimit_files                 => 32768,
+      events_mechanism             => 'epoll'
     }
 
     create_resources('php::fpm::pool',  hiera_hash('php_fpm_pool', {}))

--- a/docs/quick-start.rst
+++ b/docs/quick-start.rst
@@ -27,8 +27,13 @@ Install PHP-FPM, PHP CLI and the APC extension with custom configuration.
 
   include php
 
-  class { ['php::fpm', 'php::cli']:
+  class { 'php::cli': }
 
+  class { 'php::fpm':
+    emergency_restart_threshold  => 5,
+    emergency_restart_interval   => '1m',
+    rlimit_files                 => 32768,
+    events_mechanism             => 'epoll'  
   }
 
   class { 'php::extension::apc':

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -49,7 +49,23 @@ class php::fpm(
   $service_ensure     = $php::fpm::params::service_ensure,
   $service_enable     = $php::fpm::params::service_enable,
   $service_has_status = $php::fpm::params::service_has_status,
-  $service_provider   = $php::fpm::params::service_provider  
+  $service_provider   = $php::fpm::params::service_provider,
+
+  # settings for php-fpm.conf
+  $pid                          = $php::fpm::params::pid,
+  $error_log                    = $php::fpm::params::error_log,
+  $syslog_facility              = $php::fpm::params::syslog_facility,
+  $syslog_ident                 = $php::fpm::params::syslog_ident,
+  $log_level                    = $php::fpm::params::log_level,
+  $emergency_restart_threshold  = $php::fpm::params::emergency_restart_threshold,
+  $emergency_restart_interval   = $php::fpm::params::emergency_restart_interval,
+  $process_control_timeout      = $php::fpm::params::process_control_timeout,
+  $process_max                  = $php::fpm::params::process_max,
+  $process_priority             = $php::fpm::params::process_priority,
+  $rlimit_files                 = $php::fpm::params::rlimit_files,
+  $rlimit_core                  = $php::fpm::params::rlimit_core,
+  $events_mechanism             = $php::fpm::params::events_mechanism,
+
 ) inherits php::fpm::params {
 
   class  { 'php::fpm::package':
@@ -72,6 +88,14 @@ class php::fpm(
     config  => $settings,
     service_name => $service_name,
     require => Package[$package]
+  }
+
+  file { '/etc/php5/fpm/php-fpm.conf':
+    notify  => Service[$service_name],
+    content => template('php/fpm/php-fpm.conf.erb'),
+    owner   => root,
+    group   => root,
+    mode    => '0644',
   }
 
 }

--- a/manifests/fpm/daemon.pp
+++ b/manifests/fpm/daemon.pp
@@ -16,30 +16,6 @@ class php::fpm::daemon (
   $log_dir_mode = '0770'
 ) {
 
-  # Hack-ish to default to user for group too
-  $log_group_final = $log_group ? {
-    false   => $log_owner,
-    default => $log_group,
-  }
-
-  if ($ensure == 'present') {
-
-    service { 'php5-fpm':
-      ensure    => running,
-      enable    => true,
-      restart   => 'service php5-fpm reload',
-      hasstatus => true,
-      require   => Package['php5-fpm'],
-    }
-
-    file { '/etc/php5/fpm/php-fpm.conf':
-      notify  => Service['php5-fpm'],
-      content => template('php/fpm/php-fpm.conf.erb'),
-      owner   => root,
-      group   => root,
-      mode    => '0644',
-    }
-
-  }
+  fail('php::fpm::daemon is deprecated, please move your php-fpm.conf settings into php::fpm..')
 
 }

--- a/manifests/fpm/params.pp
+++ b/manifests/fpm/params.pp
@@ -52,4 +52,20 @@ class php::fpm::params inherits php::params {
   $service_has_status = true
   $service_provider   = undef
 
+  # default params for php-fpm.conf, ported from php::fpm::daemon
+  $pid                          = '/var/run/php5-fpm.pid'
+  $error_log                    = '/var/log/php5-fpm.log'
+  $syslog_facility              = undef
+  $syslog_ident                 = undef
+  $log_level                    = 'notice'
+  $emergency_restart_threshold  = 0
+  $emergency_restart_interval   = 0
+  $process_control_timeout      = 0
+  $process_max                  = undef
+  $process_priority             = undef
+  $daemonize                    = true
+  $rlimit_files                 = 1024
+  $rlimit_core                  = 0
+  $events_mechanism             = undef
+
 }

--- a/templates/fpm/php-fpm.conf.erb
+++ b/templates/fpm/php-fpm.conf.erb
@@ -22,27 +22,35 @@
 ; Pid file
 ; Note: the default prefix is /var
 ; Default Value: none
-pid = /var/run/php5-fpm.pid
+pid = <%= @pid %>
 
 ; Error log file
 ; If it's set to "syslog", log is sent to syslogd instead of being written
 ; in a local file.
 ; Note: the default prefix is /var
 ; Default Value: log/php-fpm.log
-error_log = /var/log/php5-fpm.log
+error_log = <%= @error_log %>
 
 ; syslog_facility is used to specify what type of program is logging the
 ; message. This lets syslogd specify that messages from different facilities
 ; will be handled differently.
 ; See syslog(3) for possible values (ex daemon equiv LOG_DAEMON)
 ; Default Value: daemon
+<% if @syslog_facility %>
+syslog.facility = <%= @syslog_facility %>
+<% else %>
 ;syslog.facility = daemon
+<% end %>
 
 ; syslog_ident is prepended to every message. If you have multiple FPM
 ; instances running on the same server, you can change the default value
 ; which must suit common needs.
 ; Default Value: php-fpm
+<% if @syslog_ident %>
+syslog.ident = <%= @syslog_ident %>
+<% else %>
 ;syslog.ident = php-fpm
+<% end %>
 
 ; Log level
 ; Possible Values: alert, error, warning, notice, debug
@@ -74,7 +82,11 @@ process_control_timeout = <%= @process_control_timeout %>
 ; Use it with caution.
 ; Note: A value of 0 indicates no limit
 ; Default Value: 0
+<% if @process_max %>
+process.max = <%= @process_max %>
+<% else %>
 ; process.max = 128
+<% end %>
 
 ; Specify the nice(2) priority to apply to the master process (only if set)
 ; The value can vary from -19 (highest priority) to 20 (lower priority)
@@ -82,20 +94,25 @@ process_control_timeout = <%= @process_control_timeout %>
 ;       - The pool process will inherit the master process priority
 ;         unless it specified otherwise
 ; Default Value: no set
+<% if @process_priority %>
+process.priority = <%= @process_priority %>
+<% else %>
 ; process.priority = -19
+<% end %>
+
 
 ; Send FPM to background. Set to 'no' to keep FPM in foreground for debugging.
 ; Default Value: yes
-;daemonize = yes
+daemonize = <%= @daemonize %>
 
 ; Set open file descriptor rlimit for the master process.
 ; Default Value: system defined value
-;rlimit_files = 1024
+rlimit_files = <%= @rlimit_files %>
 
 ; Set max core size rlimit for the master process.
 ; Possible Values: 'unlimited' or an integer greater or equal to 0
 ; Default Value: system defined value
-;rlimit_core = 0
+rlimit_core = <%= @rlimit_core %>
 
 ; Specify the event mechanism FPM will use. The following is available:
 ; - select     (any POSIX os)
@@ -105,7 +122,12 @@ process_control_timeout = <%= @process_control_timeout %>
 ; - /dev/poll  (Solaris >= 7)
 ; - port       (Solaris >= 10)
 ; Default Value: not set (auto detection)
+<% if @events_mechanism %>
+events.mechanism = <%= @events_mechanism %>
+<% else %>
 ; events.mechanism = epoll
+<% end %>
+
 
 ;;;;;;;;;;;;;;;;;;;;
 ; Pool Definitions ;


### PR DESCRIPTION
Hello

As discuss previously today, i'm sending a PR to deprecate php::fpm::daemon which was broken and outdated in favor of configuring php-fpm settings at php::fpm

Hope its fine and can be merge.

Regards

Tombar