### PR TITLE
Facter variable for PHP Extension Version, addresses issue #102, replacing pull request #103

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ spec/fixtures/
 .*.sw*
 
 .DS_Store
+.project

--- a/lib/facter/php_extension_version.rb
+++ b/lib/facter/php_extension_version.rb
@@ -1,0 +1,10 @@
+Facter.add(:php_extension_version) do
+  setcode do
+    module_api_version = Facter::Util::Resolution.exec("/usr/bin/env php -i 2>/dev/null | awk '/PHP Extension =/{print $4}'")
+    if module_api_version
+      module_api_version.match(/(\d{8})/).to_s
+    else
+      "20121212"
+    end
+  end
+end

--- a/manifests/extension/xdebug/params.pp
+++ b/manifests/extension/xdebug/params.pp
@@ -46,7 +46,7 @@ class php::extension::xdebug::params {
   $ensure      = $php::params::ensure
   $package     = 'php5-xdebug'
   $provider    = undef
-  $install_dir = '/usr/lib/php5/20121212'
+  $install_dir = "/usr/lib/php5/${::php_extension_version}"
   $inifile     = "${php::params::config_root_ini}/xdebug.ini"
   $settings    = [
     "set .anon/zend_extension '${install_dir}/xdebug.so'"


### PR DESCRIPTION
Hi,

This is a new pull request replacing pull request #103.
It adds a php_extension_version fact with only one pipe and "20121212" as default value.

Also, I added .project to .gitignore, because I worked with Gepetto IDE.