### PR TITLE
Mange PHP-FPM configuration once the package is installed

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -89,13 +89,14 @@ class php::fpm(
     service_name => $service_name,
     require => Package[$package]
   }
-  ->
+
   file { '/etc/php5/fpm/php-fpm.conf':
     notify  => Service[$service_name],
     content => template('php/fpm/php-fpm.conf.erb'),
     owner   => root,
     group   => root,
     mode    => '0644',
+    require => Package[$package]
   }
 
 }

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -73,7 +73,7 @@ class php::fpm(
     package_ensure   => $ensure,
     package_provider => $provider
   }
-
+  ->
   class  { 'php::fpm::service':
     ensure       => $service_ensure,
     service_name => $service_name,
@@ -82,14 +82,14 @@ class php::fpm(
     has_status   => $service_has_status,
     require      => Package[$package]
   }
-
+  ->
   php::fpm::config { 'php-fpm':
     file    => $inifile,
     config  => $settings,
     service_name => $service_name,
     require => Package[$package]
   }
-
+  ->
   file { '/etc/php5/fpm/php-fpm.conf':
     notify  => Service[$service_name],
     content => template('php/fpm/php-fpm.conf.erb'),

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -73,7 +73,7 @@ class php::fpm(
     package_ensure   => $ensure,
     package_provider => $provider
   }
-  ->
+
   class  { 'php::fpm::service':
     ensure       => $service_ensure,
     service_name => $service_name,
@@ -82,7 +82,7 @@ class php::fpm(
     has_status   => $service_has_status,
     require      => Package[$package]
   }
-  ->
+
   php::fpm::config { 'php-fpm':
     file    => $inifile,
     config  => $settings,


### PR DESCRIPTION
==> default: Error: /Stage[main]/Php::Fpm/File[/etc/php5/fpm/php-fpm.conf]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory - /etc/php5/fpm/php-fpm.conf20150216-9250-13qqa16.lock at 99:/home/vagrant/opt/puppet/modules/php/manifests/fpm.pp

Catalog run will fail case the PHP-FPM package is manged before the package itself is installed. I just added require parameter to file definition.

P. S. Don't get confused over branch name. I was on some xdebug issue and I named the branch on auto-pilot. ;) 