### PR TITLE
Mange PHP-FPM configuration once the package is installed

### DIFF
--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -96,6 +96,7 @@ class php::fpm(
     owner   => root,
     group   => root,
     mode    => '0644',
+    require => Package[$package]
   }
 
 }


### PR DESCRIPTION
==> default: Error: /Stage[main]/Php::Fpm/File[/etc/php5/fpm/php-fpm.conf]/ensure: change from absent to file failed: Could not set 'file' on ensure: No such file or directory - /etc/php5/fpm/php-fpm.conf20150216-9250-13qqa16.lock at 99:/home/vagrant/opt/puppet/modules/php/manifests/fpm.pp

Catalog run will fail case the PHP-FPM package is manged before the package itself is installed. I just added require parameter to file definition.

Refs #129 and #122 