### PR TITLE
Made parameter package_provider optional.

### DIFF
--- a/manifests/fpm/package.pp
+++ b/manifests/fpm/package.pp
@@ -5,7 +5,7 @@
 class php::fpm::package(
   $package_name,
   $package_ensure,
-  $package_provider
+  $package_provider = undef
 ) {
 
   package { $package_name:

--- a/spec/classes/fpm/php_fpm_package_spec.rb
+++ b/spec/classes/fpm/php_fpm_package_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'php::fpm::package', :type => :class do
+  context 'with package_name => php5-fpm' do
+    let(:params) { {:package_name => 'php5-fpm', :package_ensure => 'installed'} }
+    it { should contain_package('php5-fpm') }
+  end
+end

--- a/spec/classes/fpm_spec.rb
+++ b/spec/classes/fpm_spec.rb
@@ -1,0 +1,8 @@
+require 'spec_helper'
+
+describe 'php::fpm', :type => :class do
+  it { should contain_class('php::fpm::package') }
+  it { should contain_class('php::fpm::service').that_requires('Package[php5-fpm]') }
+  it { should contain_php__fpm__config('php-fpm').that_requires('Package[php5-fpm]') }
+  it { should contain_file('/etc/php5/fpm/php-fpm.conf').that_requires('Package[php5-fpm]') }
+end

--- a/spec/classes/php_spec.rb
+++ b/spec/classes/php_spec.rb
@@ -1,6 +1,7 @@
 require 'spec_helper'
 
 describe 'php', :type => :class do
-  it { should contain_class 'php' }
-  it { should include_class 'php::params' }
+  it { should compile.with_all_deps }
+  it { should contain_class('php') }
+  it { should contain_class('php::params') }
 end


### PR DESCRIPTION
In addition to making parameter package_provider optional I wrote basic tests for related classes. 
Note change in  spec/classes/php_spec.rb on line 5. Example was failing with 
```
TypeError: no implicit conversion of Symbol into Hash
/home/goran/.gem/ruby/2.2.0/gems/rspec-puppet-2.0.0/lib/rspec-puppet/matchers/include_class.rb:7:in `block (2 levels) in <module:ManifestMatchers>'
./spec/classes/php_spec.rb:6:in `block (2 levels) in <top (required)>'
```
include_class matcher was [deprecated](http://bombasticmonkey.com/2013/12/05/rspec-puppet-1.0.0/) in rspec-puppet 1.0 and later on removed. As advised I used contain_class instead.
close  jippi/puppet-php#131