### PR TITLE
Added support for PHP Tidy extension.

### DIFF
--- a/manifests/extension/tidy.pp
+++ b/manifests/extension/tidy.pp
@@ -33,6 +33,7 @@
 # === Authors
 #
 # Christian "Jippi" Winther <jippignu@gmail.com>
+# Goran Miskovic <schkovich@gmail.com>
 #
 # === Copyright
 #

--- a/manifests/extension/tidy.pp
+++ b/manifests/extension/tidy.pp
@@ -36,7 +36,7 @@
 #
 # === Copyright
 #
-# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+# Copyright 2012-2015 Christian "Jippi" Winther, unless otherwise noted.
 #
 class php::extension::tidy(
   $ensure   = $php::extension::tidy::params::ensure,

--- a/manifests/extension/tidy.pp
+++ b/manifests/extension/tidy.pp
@@ -1,0 +1,60 @@
+# == Class: php::extension::tidy
+#
+# Install the tidy PHP extension
+#
+# === Parameters
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Variables
+#
+# No variables
+#
+# === Examples
+#
+#  include php::extension::tidy
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::tidy(
+  $ensure   = $php::extension::tidy::params::ensure,
+  $package  = $php::extension::tidy::params::package,
+  $provider = $php::extension::tidy::params::provider,
+  $inifile  = $php::extension::tidy::params::inifile,
+  $settings = $php::extension::tidy::params::settings
+) inherits php::extension::tidy::params {
+
+  php::extension { 'tidy':
+    ensure   => $ensure,
+    package  => $package,
+    provider => $provider
+  }
+
+  php::config { 'php-extension-tidy':
+    file   => $inifile,
+    config => $settings
+  }
+
+}

--- a/manifests/extension/tidy/params.pp
+++ b/manifests/extension/tidy/params.pp
@@ -36,7 +36,7 @@
 #
 # === Copyright
 #
-# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+# Copyright 2012-2015 Christian "Jippi" Winther, unless otherwise noted.
 #
 class php::extension::tidy::params {
 

--- a/manifests/extension/tidy/params.pp
+++ b/manifests/extension/tidy/params.pp
@@ -1,0 +1,49 @@
+# == Class: php::extension::tidy::params
+#
+# Defaults file for the tidy PHP extension
+#
+# === Parameters
+#
+# No parameters
+#
+# === Variables
+#
+# [*ensure*]
+#   The version of the package to install
+#   Could be "latest", "installed" or a pinned version
+#   This matches "ensure" from Package
+#
+# [*package*]
+#   The package name in your provider
+#
+# [*provider*]
+#   The provider used to install the package
+#
+# [*inifile*]
+#   The path to the extension ini file
+#
+# [*settings*]
+#   Hash with 'set' nested hash of key => value
+#   set changes to agues when applied to *inifile*
+#
+# === Examples
+#
+# No examples
+#
+# === Authors
+#
+# Christian "Jippi" Winther <jippignu@gmail.com>
+#
+# === Copyright
+#
+# Copyright 2012-2013 Christian "Jippi" Winther, unless otherwise noted.
+#
+class php::extension::tidy::params {
+
+  $ensure   = $php::params::ensure
+  $package  = 'php5-tidy'
+  $provider = undef
+  $inifile  = "${php::params::config_root_ini}/tidy.ini"
+  $settings = [ ]
+
+}

--- a/manifests/extension/tidy/params.pp
+++ b/manifests/extension/tidy/params.pp
@@ -33,6 +33,7 @@
 # === Authors
 #
 # Christian "Jippi" Winther <jippignu@gmail.com>
+# Goran Miskovic <schkovich@gmail.com>
 #
 # === Copyright
 #


### PR DESCRIPTION
[Tidy](http://php.net/manual/en/book.tidy.php) is a binding for the Tidy HTML clean and repair utility which allows you to not only clean and otherwise manipulate HTML documents, but also traverse the document tree. 