### PR TITLE
php::phpunit defaults 

### DIFF
--- a/manifests/phpunit/params.pp
+++ b/manifests/phpunit/params.pp
@@ -12,21 +12,21 @@
 #   The ensure of the pear package to install
 #   Could be "latest", "installed" or a pinned verison
 #
-# [*package*]
-#   The package name for pear package
-#   For debian it's pear.phpunit.de/PHPUnit
+# [*source*]
+#   The URL to download PHPUnit PHAR
+#   Official URL is https://phar.phpunit.de/phpunit.phar
 #
-# [*provider*]
+# [*destination*]
 #   The provider used to install pear.phpunit.de/PHPUnit
-#   Could be "pecl", "apt" or any other OS package provider
+#   Recommended install location is /usr/local/bin/phpunit
 #
 #
 # === Examples
 #
-#  include 'php::pear::package'
+#  include 'php::phpunit'
 #
-#  class {'php::pear::package
-#   ensure => latest
+#  class {'php::phpunit
+#   destination => '/opt/phpunit'
 #  }
 #
 # === Authors
@@ -40,7 +40,6 @@
 class php::phpunit::params inherits php::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'pear.phpunit.de/PHPUnit'
-  $provider = 'pear'
-
+  $source = 'https://phar.phpunit.de/phpunit.phar'
+  $destination = '/usr/local/bin/phpunit'
 }

--- a/spec/classes/phpunit_spec.rb
+++ b/spec/classes/phpunit_spec.rb
@@ -1,0 +1,27 @@
+require 'spec_helper'
+
+describe 'php::phpunit', :type => :class do
+  let :pre_condition do
+    'include "php::cli"'
+  end
+  context 'default install' do
+    default_destination = '/usr/local/bin/phpunit'
+    default_source = 'https://phar.phpunit.de/phpunit.phar'
+    it { should contain_exec('download phpunit').with({
+                                                          'creates' => default_destination,
+                                                          'command' => "wget #{default_source} -O #{default_destination}"
+                                                      })
+      # .that_requires("Package['php5-cli']").that_comes_before("File[#{default_destination}")
+    }
+    it { should contain_exec('download phpunit').that_requires('Package[php5-cli]') }
+    it { should contain_exec('download phpunit').that_comes_before("File[#{default_destination}]") }
+    it { should contain_file(default_destination).with({
+                                                           'ensure' => 'present',
+                                                           'mode' => '0555',
+                                                           'owner' => 'root',
+                                                           'group' => 'root'
+                                                       })
+    }
+
+  end
+end


### PR DESCRIPTION
In pull request jippi/puppet-php#128 class php::phpunit was change to install PHPUnit phar archive instead of deprecated PEAR method. However corresponding parameters class was not updated causing following error:

```
Error: Parameter path failed on File[undef]: File paths must be fully qualified, not 'undef' at /home/vagrant/opt/puppet/modules/php/manifests/phpunit.pp:55
```

Updated php::phpunit::params class and added basic tests.

refs jippi/puppet-php#128
refs jippi/puppet-php#104