### PR TITLE
Setting parameter php::fpm::service::provider to be optional. refs jippy...

### DIFF
--- a/manifests/fpm/service.pp
+++ b/manifests/fpm/service.pp
@@ -7,7 +7,7 @@ class php::fpm::service(
   $ensure,
   $enable,
   $has_status,
-  $provider
+  $provider = undef
 ) {
 
   service { $service_name:


### PR DESCRIPTION
Setting parameter php::fpm::service::provider to be optional. refs jippi/puppet-php#134