### PR TITLE
Remove pfp5-pool file requires fpm Package

### DIFF
--- a/manifests/fpm/pool.pp
+++ b/manifests/fpm/pool.pp
@@ -66,7 +66,8 @@ define php::fpm::pool (
   if ($ensure == 'absent') {
     file { "/etc/php5/fpm/pool.d/${pool}.conf":
       ensure => absent,
-      notify => Service['php5-fpm']
+      notify => Service['php5-fpm'],
+      require => Package['php5-fpm'],
     }
   } else {
     file { "/etc/php5/fpm/pool.d/${pool}.conf":


### PR DESCRIPTION
We run into an issue, when removing the default pool configuration ('www') on the first puppet run.
It happend, that the file resource, to remove the `/etc/php5/fpm/pool.d/www.conf` run before the package php5-fpm was installed. So Puppet ignored it (the file did not exist at this time) and then installed php5-fpm with the default configuration we wanted to remove.

This PR adds a requirement of the php5-fpm package also for the case you want ro remove a config file.

(So many words for just one line in code...) :)


