### PR TITLE
Ensure greater consistency between php extensions

### DIFF
--- a/manifests/extension/apc/params.pp
+++ b/manifests/extension/apc/params.pp
@@ -59,6 +59,8 @@ class php::extension::apc::params {
   }
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/apc.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "apc.so"'
+  ]
 
 }

--- a/manifests/extension/apcu/params.pp
+++ b/manifests/extension/apcu/params.pp
@@ -44,5 +44,7 @@ class php::extension::apcu::params {
   $package  = 'php5-apcu'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/apcu.ini"
-  $settings = []
+  $settings = [
+    'set ".anon/extension" "apcu.so"'
+  ]
 }

--- a/manifests/extension/curl/params.pp
+++ b/manifests/extension/curl/params.pp
@@ -44,6 +44,8 @@ class php::extension::curl::params {
   $package  = 'php5-curl'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/curl.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "curl.so"'
+  ]
 
 }

--- a/manifests/extension/gd/params.pp
+++ b/manifests/extension/gd/params.pp
@@ -44,6 +44,8 @@ class php::extension::gd::params {
   $package  = 'php5-gd'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/gd.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "gd.so"'
+  ]
 
 }

--- a/manifests/extension/gearman/params.pp
+++ b/manifests/extension/gearman/params.pp
@@ -44,6 +44,8 @@ class php::extension::gearman::params {
   $package  = 'php5-gearman'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/gearman.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "gearman.so"'
+  ]
 
 }

--- a/manifests/extension/http/params.pp
+++ b/manifests/extension/http/params.pp
@@ -44,6 +44,8 @@ class php::extension::http::params {
   $package  = 'php5-http'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/http.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "http.so"'
+  ]
 
 }

--- a/manifests/extension/imagick/params.pp
+++ b/manifests/extension/imagick/params.pp
@@ -44,6 +44,8 @@ class php::extension::imagick::params {
   $package  = 'php5-imagick'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/imagick.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "imagick.so"'
+  ]
 
 }

--- a/manifests/extension/imap/params.pp
+++ b/manifests/extension/imap/params.pp
@@ -44,5 +44,7 @@ class php::extension::imap::params {
   $package  = 'php5-imap'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/imap.ini"
-  $settings = []
+  $settings = [
+    'set ".anon/extension" "imap.so"'
+  ]
 }

--- a/manifests/extension/imap/params.pp
+++ b/manifests/extension/imap/params.pp
@@ -43,6 +43,6 @@ class php::extension::imap::params {
   $ensure   = $php::params::ensure
   $package  = 'php5-imap'
   $provider = undef
-  $inifile  = '/etc/php5/conf.d/20-imap.ini'
+  $inifile  = "${php::params::config_root_ini}/imap.ini"
   $settings = []
 }

--- a/manifests/extension/intl/params.pp
+++ b/manifests/extension/intl/params.pp
@@ -44,6 +44,8 @@ class php::extension::intl::params {
   $package  = 'php5-intl'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/intl.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "intl.so"'
+  ]
 
 }

--- a/manifests/extension/ldap/params.pp
+++ b/manifests/extension/ldap/params.pp
@@ -44,5 +44,7 @@ class php::extension::ldap::params {
   $package  = 'php5-ldap'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/ldap.ini"
-  $settings = []
+  $settings = [
+    'set ".anon/extension" "ldap.so"'
+  ]
 }

--- a/manifests/extension/ldap/params.pp
+++ b/manifests/extension/ldap/params.pp
@@ -43,6 +43,6 @@ class php::extension::ldap::params {
   $ensure   = $php::params::ensure
   $package  = 'php5-ldap'
   $provider = undef
-  $inifile  = '/etc/php5/conf.d/20-ldap.ini'
+  $inifile  = "${php::params::config_root_ini}/ldap.ini"
   $settings = []
 }

--- a/manifests/extension/mcrypt/params.pp
+++ b/manifests/extension/mcrypt/params.pp
@@ -44,6 +44,8 @@ class php::extension::mcrypt::params {
   $package  = 'php5-mcrypt'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/mcrypt.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "mcrypt.so"'
+  ]
 
 }

--- a/manifests/extension/memcache/params.pp
+++ b/manifests/extension/memcache/params.pp
@@ -44,7 +44,7 @@ class php::extension::memcache::params {
   $ensure   = $php::params::ensure
   $package  = 'php5-memcache'
   $provider = undef
-  $inifile  = '/etc/php5/conf.d/20-memcache.ini'
+  $inifile  = "${php::params::config_root_ini}/memcache.ini"
   $settings = []
 
 }

--- a/manifests/extension/memcache/params.pp
+++ b/manifests/extension/memcache/params.pp
@@ -45,6 +45,8 @@ class php::extension::memcache::params {
   $package  = 'php5-memcache'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/memcache.ini"
-  $settings = []
+  $settings = [
+    'set ".anon/extension" "memcache.so"'
+  ]
 
 }

--- a/manifests/extension/memcached/params.pp
+++ b/manifests/extension/memcached/params.pp
@@ -45,6 +45,8 @@ class php::extension::memcached::params {
   $package  = 'php5-memcached'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/memcached.ini"
-  $settings = []
+  $settings = [
+    'set ".anon/extension" "memcached.so"'
+  ]
 
 }

--- a/manifests/extension/memcached/params.pp
+++ b/manifests/extension/memcached/params.pp
@@ -44,7 +44,7 @@ class php::extension::memcached::params {
   $ensure   = $php::params::ensure
   $package  = 'php5-memcached'
   $provider = undef
-  $inifile  = '/etc/php5/conf.d/20-memcached.ini'
+  $inifile  = "${php::params::config_root_ini}/memcached.ini"
   $settings = []
 
 }

--- a/manifests/extension/mysql/params.pp
+++ b/manifests/extension/mysql/params.pp
@@ -44,6 +44,8 @@ class php::extension::mysql::params {
   $package  = 'php5-mysql'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/mysql.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "mysql.so"'
+  ]
 
 }

--- a/manifests/extension/mysqlnd/params.pp
+++ b/manifests/extension/mysqlnd/params.pp
@@ -44,6 +44,8 @@ class php::extension::mysqlnd::params {
   $package  = 'php5-mysqlnd'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/mysqlnd.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "mysqlnd.so"'
+  ]
 
 }

--- a/manifests/extension/newrelic/params.pp
+++ b/manifests/extension/newrelic/params.pp
@@ -44,6 +44,8 @@ class php::extension::newrelic::params {
   $package  = 'newrelic-php5'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/newrelic.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "newrelic.so"'
+  ]
 
 }

--- a/manifests/extension/opcache/params.pp
+++ b/manifests/extension/opcache/params.pp
@@ -44,6 +44,8 @@ class php::extension::opcache::params {
   $package  = undef
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/opcache.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "opcache.so"'
+  ]
 
 }

--- a/manifests/extension/pgsql/params.pp
+++ b/manifests/extension/pgsql/params.pp
@@ -44,5 +44,7 @@ class php::extension::pgsql::params {
   $package  = 'php5-pgsql'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/pgsql.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "pgsql.so"'
+  ]
 }

--- a/manifests/extension/redis/params.pp
+++ b/manifests/extension/redis/params.pp
@@ -44,6 +44,8 @@ class php::extension::redis::params {
   $package  = 'php5-redis'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/redis.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "redis.so"'
+  ]
 
 }

--- a/manifests/extension/solr/params.pp
+++ b/manifests/extension/solr/params.pp
@@ -45,6 +45,8 @@ class php::extension::solr::params {
   $package  = 'solr'
   $provider = 'pecl'
   $inifile  = "${php::params::config_root_ini}/solr.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "solr.so"'
+  ]
 
 }

--- a/manifests/extension/sqlite/params.pp
+++ b/manifests/extension/sqlite/params.pp
@@ -44,5 +44,7 @@ class php::extension::sqlite::params {
   $package  = 'php5-sqlite'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/sqlite.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "sqlite.so"'
+  ]
 }

--- a/manifests/extension/ssh2/params.pp
+++ b/manifests/extension/ssh2/params.pp
@@ -44,6 +44,8 @@ class php::extension::ssh2::params {
   $package  = 'php5-ssh2'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/ssh2.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "ssh2.so"'
+  ]
 
 }

--- a/manifests/extension/tidy/params.pp
+++ b/manifests/extension/tidy/params.pp
@@ -45,6 +45,8 @@ class php::extension::tidy::params {
   $package  = 'php5-tidy'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/tidy.ini"
-  $settings = [ ]
+  $settings = [
+    'set ".anon/extension" "tidy.so"'
+  ]
 
 }

--- a/manifests/extension/xcache/params.pp
+++ b/manifests/extension/xcache/params.pp
@@ -44,6 +44,8 @@ class php::extension::xcache::params {
   $package  = 'php5-xcache'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/xcache.ini"
-  $settings = []
+  $settings = [
+    'set ".anon/extension" "xcache.so"'
+  ]
 
 }

--- a/manifests/extension/xdebug/params.pp
+++ b/manifests/extension/xdebug/params.pp
@@ -19,9 +19,6 @@
 # [*provider*]
 #   The provider used to install the package
 #
-# [*install_dir*]
-#   The path of the installed xdebug.so binary
-#
 # [*inifile*]
 #   The path to the extension ini file
 #
@@ -46,7 +43,6 @@ class php::extension::xdebug::params {
   $ensure      = $php::params::ensure
   $package     = 'php5-xdebug'
   $provider    = undef
-  $install_dir = "/usr/lib/php5/${::php_extension_version}"
   $inifile     = "${php::params::config_root_ini}/xdebug.ini"
   $settings    = [
     'set ".anon/zend_extension" "xdebug.so"'

--- a/manifests/extension/xdebug/params.pp
+++ b/manifests/extension/xdebug/params.pp
@@ -49,7 +49,7 @@ class php::extension::xdebug::params {
   $install_dir = "/usr/lib/php5/${::php_extension_version}"
   $inifile     = "${php::params::config_root_ini}/xdebug.ini"
   $settings    = [
-    "set .anon/zend_extension '${install_dir}/xdebug.so'"
+    'set ".anon/zend_extension" "xdebug.so"'
   ]
 
 }

--- a/manifests/extension/xhprof/params.pp
+++ b/manifests/extension/xhprof/params.pp
@@ -19,9 +19,6 @@
 # [*provider*]
 #   The provider used to install the package
 #
-# [*install_dir*]
-#   The path of the installed xhprof.so binary
-#
 # [*inifile*]
 #   The path to the extension ini file
 #


### PR DESCRIPTION
- Use php::params::config_root_ini for ini files path :
    * imap
    * ldap
    * memcache
    * memcached
- Add default settings for all extension
- Remove unnecessary settings and comments