### PR TITLE
Leave the 'listen.allowed_clients' directive commented in case there …

### DIFF
--- a/templates/fpm/pool.conf.erb
+++ b/templates/fpm/pool.conf.erb
@@ -12,7 +12,11 @@ listen.backlog = <%= @listen_backlog %>
 ; must be separated by a comma. If this value is left blank, connections will be
 ; accepted from any ip address.
 ; Default Value: any
+<% if @listen_allowed_clients and !@listen_allowed_clients.empty? -%>
 listen.allowed_clients = <%= @listen_allowed_clients %>
+<% else -%>
+;listen.allowed_clients = 127.0.0.1
+<% end -%>
 
 ; Set permissions for unix socket, if one is used. In Linux, read/write
 ; permissions must be set in order to allow connections from a web server. Many


### PR DESCRIPTION
A fix for issue #158.

This will check for an empty @listen_allowed_clients and will render a commented 'dummy' placeholder. This approach will preserve BC as the value by default is still '127.0.0.1' and one must explicitly override it in order to disable the filtering by "listen.allowed_clients"

