### PR TITLE
Include php::params in php::cli::params

### DIFF
--- a/manifests/cli/params.pp
+++ b/manifests/cli/params.pp
@@ -40,6 +40,8 @@
 #
 class php::cli::params {
 
+  include php::params
+  
   $ensure   = $php::params::ensure
   $package  = 'php5-cli'
   $provider = undef


### PR DESCRIPTION
When declaring the php::cli class, the $php::params::ensure variable cannot be resolved if
the php::params class is not available. This results in the following warning:
```
(Scope(Class[Php::Cli::Params])) Could not look up qualified variable 'php::params::ensure'; class php::params has not been evaluated
```
Including the php::params class in php::cli ensures the availability of the variables contained therein.