### PR TITLE
Remove curl dependency and modernize apt usage

### DIFF
--- a/manifests/apt.pp
+++ b/manifests/apt.pp
@@ -49,14 +49,11 @@ class php::apt(
       }
     }
 
-    exec { 'add_dotdeb_key':
-      command =>
-      'curl -L --silent "http://www.dotdeb.org/dotdeb.gpg" | apt-key add -',
-      unless  => 'apt-key list | grep -q dotdeb',
-      path    => [ '/bin/', '/sbin/' , '/usr/bin/', '/usr/sbin/' ];
+    apt::key { 'add_dotdeb_key':
+      key => '6572BBEF1B5FF28B28B706837E3F070089DF5277',
     }
 
-    Exec['add_dotdeb_key'] -> Apt::Source["source_php_${release}"]
+    Apt::Key['add_dotdeb_key'] -> Apt::Source["source_php_${release}"]
   }
 
 }


### PR DESCRIPTION
This change uses the apt::key defined type to add the dotdeb key,
thereby removing the exec and dependency on curl.