### PR TITLE
Version switch

### DIFF
--- a/manifests/apache/params.pp
+++ b/manifests/apache/params.pp
@@ -41,11 +41,37 @@
 class php::apache::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'libapache2-mod-php5'
   $provider = undef
-  $inifile  = '/etc/php/7.0/apache2/php.ini'
   $settings = [ ]
 
-  $service_name = 'apache2'
-
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $service_name   = 'apache2'
+            $package        = 'libapache2-mod-php7.0'
+            $inifile        = '/etc/php/7.0/apache2/php.ini'
+          } else {
+            $service_name   = 'apache2'
+            $package        = 'libapache2-mod-php5'
+            $inifile        = '/etc/php5/apache2/php.ini'
+          }
+        }
+        default: {
+          $server_name  = 'apache2'
+          $package      = 'libapache2-mod-php7.0'
+          $inifile      = '/etc/php/7.0/apache2/php.ini'
+        }
+      }
+    }
+    #
+    # @todo RedHat uses 'httpd' as service name
+    #
+    default: {
+      $service_name     = 'apache2'
+      $package          = 'libapache2-mod-php7.0'
+      $inifile          = '/etc/php/7.0/apache2/php.ini'
+    }
+  }
 }

--- a/manifests/apache/params.pp
+++ b/manifests/apache/params.pp
@@ -48,7 +48,7 @@ class php::apache::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $service_name   = 'apache2'
             $package        = 'libapache2-mod-php7.0'
             $inifile        = '/etc/php/7.0/apache2/php.ini'

--- a/manifests/cli/params.pp
+++ b/manifests/cli/params.pp
@@ -48,7 +48,7 @@ class php::cli::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $inifile        = '/etc/php/7.0/cli/php.ini'
             $package        = 'php7.0-cli'
           } else {

--- a/manifests/cli/params.pp
+++ b/manifests/cli/params.pp
@@ -41,9 +41,30 @@
 class php::cli::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-cli'
   $provider = undef
-  $inifile  = '/etc/php/7.0/cli/php.ini'
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $inifile        = '/etc/php/7.0/cli/php.ini'
+            $package        = 'php7.0-cli'
+          } else {
+            $inifile        = '/etc/php5/cli/php.ini'
+            $package        = 'php5-cli'
+          }
+        }
+        default: {
+          $inifile      = '/etc/php/7.0/cli/php.ini'
+          $package      = 'php7.0-cli'
+        }
+      }
+    }
+    default: {
+      $inifile      = '/etc/php/7.0/cli/php.ini'
+      $package      = 'php7.0-cli'
+    }
+  }
 }

--- a/manifests/config/augeas.pp
+++ b/manifests/config/augeas.pp
@@ -3,10 +3,10 @@ define php::config::augeas (
   $file,
   $config,
 ) {
-  include php::augeas
-  include php::params
+  include ::php::augeas
+  include ::php::params
 
-  augeas { "php-${name}-config":
+  augeas { $name:
     incl      => $file,
     changes   => $config,
     load_path => $php::params::augeas_contrib_dir,

--- a/manifests/contrib/base_package.pp
+++ b/manifests/contrib/base_package.pp
@@ -36,7 +36,7 @@ define php::contrib::base_package(
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-common'
           } else {
             $package        = 'php5-common'

--- a/manifests/contrib/base_package.pp
+++ b/manifests/contrib/base_package.pp
@@ -32,9 +32,28 @@ define php::contrib::base_package(
   $ensure,
   $provider = undef
 ) {
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-common'
+          } else {
+            $package        = 'php5-common'
+          }
+        }
+        default: {
+          $package      = 'php7.0-common'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-common'
+    }
+  }
 
-  if !defined(Package['php7.0-common']) {
-    package { 'php7.0-common':
+  if !defined(Package[$package]) {
+    package { $package:
       ensure   => $ensure,
       provider => $provider
     }

--- a/manifests/dev/params.pp
+++ b/manifests/dev/params.pp
@@ -34,7 +34,25 @@
 class php::dev::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-dev'
   $provider = undef
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-dev'
+          } else {
+            $package        = 'php5-dev'
+          }
+        }
+        default: {
+          $package      = 'php7.0-dev'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-dev'
+    }
+  }
 }

--- a/manifests/dev/params.pp
+++ b/manifests/dev/params.pp
@@ -40,7 +40,7 @@ class php::dev::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-dev'
           } else {
             $package        = 'php5-dev'

--- a/manifests/extension/apc/params.pp
+++ b/manifests/extension/apc/params.pp
@@ -41,24 +41,27 @@
 class php::extension::apc::params {
 
   $ensure   = $php::params::ensure
-  $package  = $::lsbdistcodename ? {
-    # php-apc is phased out as of Ubuntu 13.10 (saucy)
-    # and Debian jessie in favour of php5-apcu
-    # Debian
-    'squeeze' => 'php-apc',
-    'wheezy' => 'php-apc',
-
-    # Ubuntu
-    'lucid' => 'php-apc',
-    'precise' => 'php-apc',
-    'quantal' => 'php-apc',
-    'raring' => 'php-apc',
-
-    # Default to support future distros cleanly.
-    default => 'php7.0-apcu',
-  }
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/apc.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php-apcu'
+          } else {
+            $package        = 'php-apc'
+          }
+        }
+        default: {
+          $package      = 'php-apc'
+        }
+      }
+    }
+    default: {
+      $package      = 'php-apc'
+    }
+  }
 }

--- a/manifests/extension/apc/params.pp
+++ b/manifests/extension/apc/params.pp
@@ -49,7 +49,7 @@ class php::extension::apc::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php-apcu'
           } else {
             $package        = 'php-apc'

--- a/manifests/extension/apcu/params.pp
+++ b/manifests/extension/apcu/params.pp
@@ -41,8 +41,27 @@
 class php::extension::apcu::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-apcu'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/apcu.ini"
   $settings = []
+
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-apcu'
+          } else {
+            $package        = 'php5-apcu'
+          }
+        }
+        default: {
+          $package      = 'php7.0-apcu'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-apcu'
+    }
+  }
 }

--- a/manifests/extension/apcu/params.pp
+++ b/manifests/extension/apcu/params.pp
@@ -49,7 +49,7 @@ class php::extension::apcu::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-apcu'
           } else {
             $package        = 'php5-apcu'

--- a/manifests/extension/curl/params.pp
+++ b/manifests/extension/curl/params.pp
@@ -49,7 +49,7 @@ class php::extension::curl::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-curl'
           } else {
             $package        = 'php5-curl'

--- a/manifests/extension/curl/params.pp
+++ b/manifests/extension/curl/params.pp
@@ -41,9 +41,27 @@
 class php::extension::curl::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-curl'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/curl.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-curl'
+          } else {
+            $package        = 'php5-curl'
+          }
+        }
+        default: {
+          $package      = 'php7.0-curl'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-curl'
+    }
+  }
 }

--- a/manifests/extension/gd/params.pp
+++ b/manifests/extension/gd/params.pp
@@ -41,9 +41,27 @@
 class php::extension::gd::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-gd'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/gd.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-gd'
+          } else {
+            $package        = 'php5-gd'
+          }
+        }
+        default: {
+          $package      = 'php7.0-gd'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-gd'
+    }
+  }
 }

--- a/manifests/extension/gd/params.pp
+++ b/manifests/extension/gd/params.pp
@@ -49,7 +49,7 @@ class php::extension::gd::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-gd'
           } else {
             $package        = 'php5-gd'

--- a/manifests/extension/gearman/params.pp
+++ b/manifests/extension/gearman/params.pp
@@ -49,7 +49,7 @@ class php::extension::gearman::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-gearman'
           } else {
             $package        = 'php5-gearman'

--- a/manifests/extension/gearman/params.pp
+++ b/manifests/extension/gearman/params.pp
@@ -41,9 +41,27 @@
 class php::extension::gearman::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-gearman'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/gearman.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-gearman'
+          } else {
+            $package        = 'php5-gearman'
+          }
+        }
+        default: {
+          $package      = 'php7.0-gearman'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-gearman'
+    }
+  }
 }

--- a/manifests/extension/http/params.pp
+++ b/manifests/extension/http/params.pp
@@ -46,4 +46,23 @@ class php::extension::http::params {
   $inifile  = "${php::params::config_root_ini}/http.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-http'
+          } else {
+            warning('php::extension::http package does not exists on php5')
+          }
+        }
+        default: {
+          $package      = 'php7.0-http'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-http'
+    }
+  }
 }

--- a/manifests/extension/http/params.pp
+++ b/manifests/extension/http/params.pp
@@ -50,7 +50,7 @@ class php::extension::http::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-http'
           } else {
             warning('php::extension::http package does not exists on php5')

--- a/manifests/extension/igbinary/params.pp
+++ b/manifests/extension/igbinary/params.pp
@@ -49,7 +49,7 @@ class php::extension::igbinary::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-igbinary'
           } else {
             $package        = 'php5-igbinary'

--- a/manifests/extension/igbinary/params.pp
+++ b/manifests/extension/igbinary/params.pp
@@ -41,9 +41,27 @@
 class php::extension::igbinary::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-igbinary'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/igbinary.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-igbinary'
+          } else {
+            $package        = 'php5-igbinary'
+          }
+        }
+        default: {
+          $package      = 'php7.0-igbinary'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-igbinary'
+    }
+  }
 }

--- a/manifests/extension/imagick/params.pp
+++ b/manifests/extension/imagick/params.pp
@@ -49,7 +49,7 @@ class php::extension::imagick::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-imagick'
           } else {
             $package        = 'php5-imagick'

--- a/manifests/extension/imagick/params.pp
+++ b/manifests/extension/imagick/params.pp
@@ -41,9 +41,27 @@
 class php::extension::imagick::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-imagick'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/imagick.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-imagick'
+          } else {
+            $package        = 'php5-imagick'
+          }
+        }
+        default: {
+          $package      = 'php7.0-imagick'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-imagick'
+    }
+  }
 }

--- a/manifests/extension/imap/params.pp
+++ b/manifests/extension/imap/params.pp
@@ -41,8 +41,27 @@
 class php::extension::imap::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-imap'
   $provider = undef
-  $inifile  = '/etc/php/conf.d/imap.ini'
+  $inifile  = "${php::params::config_root_ini}/imap.ini"
   $settings = []
+
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-imap'
+          } else {
+            $package        = 'php5-imap'
+          }
+        }
+        default: {
+          $package      = 'php7.0-imap'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-imap'
+    }
+  }
 }

--- a/manifests/extension/imap/params.pp
+++ b/manifests/extension/imap/params.pp
@@ -49,7 +49,7 @@ class php::extension::imap::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-imap'
           } else {
             $package        = 'php5-imap'

--- a/manifests/extension/intl/params.pp
+++ b/manifests/extension/intl/params.pp
@@ -49,7 +49,7 @@ class php::extension::intl::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-intl'
           } else {
             $package        = 'php5-intl'

--- a/manifests/extension/intl/params.pp
+++ b/manifests/extension/intl/params.pp
@@ -41,9 +41,27 @@
 class php::extension::intl::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-intl'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/intl.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-intl'
+          } else {
+            $package        = 'php5-intl'
+          }
+        }
+        default: {
+          $package      = 'php7.0-intl'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-intl'
+    }
+  }
 }

--- a/manifests/extension/jsmin/params.pp
+++ b/manifests/extension/jsmin/params.pp
@@ -47,5 +47,4 @@ class php::extension::jsmin::params {
   $settings = [
     'set ".anon/extension" "jsmin.so"'
   ]
-
 }

--- a/manifests/extension/ldap/params.pp
+++ b/manifests/extension/ldap/params.pp
@@ -49,7 +49,7 @@ class php::extension::ldap::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-ldap'
           } else {
             $package        = 'php5-ldap'

--- a/manifests/extension/ldap/params.pp
+++ b/manifests/extension/ldap/params.pp
@@ -41,8 +41,27 @@
 class php::extension::ldap::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php5-ldap'
   $provider = undef
   $inifile  = '/etc/php/7.0/conf.d/20-ldap.ini'
   $settings = []
+
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-ldap'
+          } else {
+            $package        = 'php5-ldap'
+          }
+        }
+        default: {
+          $package      = 'php7.0-ldap'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-ldap'
+    }
+  }
 }

--- a/manifests/extension/mcrypt/params.pp
+++ b/manifests/extension/mcrypt/params.pp
@@ -41,9 +41,27 @@
 class php::extension::mcrypt::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-mcrypt'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/mcrypt.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-mcrypt'
+          } else {
+            $package        = 'php5-mcrypt'
+          }
+        }
+        default: {
+          $package      = 'php7.0-mcrypt'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-mcrypt'
+    }
+  }
 }

--- a/manifests/extension/mcrypt/params.pp
+++ b/manifests/extension/mcrypt/params.pp
@@ -49,7 +49,7 @@ class php::extension::mcrypt::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-mcrypt'
           } else {
             $package        = 'php5-mcrypt'

--- a/manifests/extension/memcache/params.pp
+++ b/manifests/extension/memcache/params.pp
@@ -42,9 +42,27 @@
 class php::extension::memcache::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-memcache'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/memcache.ini"
   $settings = []
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-memcache'
+          } else {
+            $package        = 'php5-memcache'
+          }
+        }
+        default: {
+          $package      = 'php7.0-memcache'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-memcache'
+    }
+  }
 }

--- a/manifests/extension/memcache/params.pp
+++ b/manifests/extension/memcache/params.pp
@@ -50,7 +50,7 @@ class php::extension::memcache::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-memcache'
           } else {
             $package        = 'php5-memcache'

--- a/manifests/extension/memcached/params.pp
+++ b/manifests/extension/memcached/params.pp
@@ -50,7 +50,7 @@ class php::extension::memcached::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-memcached'
           } else {
             $package        = 'php5-memcached'

--- a/manifests/extension/memcached/params.pp
+++ b/manifests/extension/memcached/params.pp
@@ -42,9 +42,27 @@
 class php::extension::memcached::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-memcached'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/memcached.ini"
   $settings = []
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-memcached'
+          } else {
+            $package        = 'php5-memcached'
+          }
+        }
+        default: {
+          $package      = 'php7.0-memcached'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-memcached'
+    }
+  }
 }

--- a/manifests/extension/mysql/params.pp
+++ b/manifests/extension/mysql/params.pp
@@ -41,9 +41,27 @@
 class php::extension::mysql::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-mysql'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/mysql.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-mysql'
+          } else {
+            $package        = 'php5-mysql'
+          }
+        }
+        default: {
+          $package      = 'php7.0-mysql'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-mysql'
+    }
+  }
 }

--- a/manifests/extension/mysql/params.pp
+++ b/manifests/extension/mysql/params.pp
@@ -49,7 +49,7 @@ class php::extension::mysql::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-mysql'
           } else {
             $package        = 'php5-mysql'

--- a/manifests/extension/mysqlnd/params.pp
+++ b/manifests/extension/mysqlnd/params.pp
@@ -41,9 +41,27 @@
 class php::extension::mysqlnd::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-mysqlnd'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/mysqlnd.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-mysqlnd'
+          } else {
+            $package        = 'php5-mysqlnd'
+          }
+        }
+        default: {
+          $package      = 'php7.0-mysqlnd'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-mysqlnd'
+    }
+  }
 }

--- a/manifests/extension/mysqlnd/params.pp
+++ b/manifests/extension/mysqlnd/params.pp
@@ -49,7 +49,7 @@ class php::extension::mysqlnd::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-mysqlnd'
           } else {
             $package        = 'php5-mysqlnd'

--- a/manifests/extension/newrelic/params.pp
+++ b/manifests/extension/newrelic/params.pp
@@ -49,7 +49,7 @@ class php::extension::newrelic::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'newrelic-php7'
           } else {
             $package        = 'newrelic-php5'

--- a/manifests/extension/newrelic/params.pp
+++ b/manifests/extension/newrelic/params.pp
@@ -41,9 +41,27 @@
 class php::extension::newrelic::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'newrelic-php5'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/newrelic.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'newrelic-php7'
+          } else {
+            $package        = 'newrelic-php5'
+          }
+        }
+        default: {
+          $package      = 'newrelic-php5'
+        }
+      }
+    }
+    default: {
+      $package      = 'newrelic-php5'
+    }
+  }
 }

--- a/manifests/extension/pgsql/params.pp
+++ b/manifests/extension/pgsql/params.pp
@@ -41,8 +41,27 @@
 class php::extension::pgsql::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-pgsql'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/pgsql.ini"
   $settings = [ ]
+
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-pgsql'
+          } else {
+            $package        = 'php5-pgsql'
+          }
+        }
+        default: {
+          $package      = 'php7.0-pgsql'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-pgsql'
+    }
+  }
 }

--- a/manifests/extension/pgsql/params.pp
+++ b/manifests/extension/pgsql/params.pp
@@ -49,7 +49,7 @@ class php::extension::pgsql::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-pgsql'
           } else {
             $package        = 'php5-pgsql'

--- a/manifests/extension/redis/params.pp
+++ b/manifests/extension/redis/params.pp
@@ -49,7 +49,7 @@ class php::extension::redis::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-redis'
           } else {
             $package        = 'php5-redis'

--- a/manifests/extension/redis/params.pp
+++ b/manifests/extension/redis/params.pp
@@ -41,9 +41,27 @@
 class php::extension::redis::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-redis'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/redis.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-redis'
+          } else {
+            $package        = 'php5-redis'
+          }
+        }
+        default: {
+          $package      = 'php7.0-redis'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-redis'
+    }
+  }
 }

--- a/manifests/extension/sqlite/params.pp
+++ b/manifests/extension/sqlite/params.pp
@@ -49,7 +49,7 @@ class php::extension::sqlite::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-sqlite'
           } else {
             $package        = 'php5-sqlite'

--- a/manifests/extension/sqlite/params.pp
+++ b/manifests/extension/sqlite/params.pp
@@ -41,8 +41,27 @@
 class php::extension::sqlite::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-sqlite'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/sqlite.ini"
   $settings = [ ]
+
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-sqlite'
+          } else {
+            $package        = 'php5-sqlite'
+          }
+        }
+        default: {
+          $package      = 'php7.0-sqlite'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-sqlite'
+    }
+  }
 }

--- a/manifests/extension/ssh2/params.pp
+++ b/manifests/extension/ssh2/params.pp
@@ -49,7 +49,7 @@ class php::extension::ssh2::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-ssh2'
           } else {
             $package        = 'php5-ssh2'

--- a/manifests/extension/ssh2/params.pp
+++ b/manifests/extension/ssh2/params.pp
@@ -41,9 +41,27 @@
 class php::extension::ssh2::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-ssh2'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/ssh2.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-ssh2'
+          } else {
+            $package        = 'php5-ssh2'
+          }
+        }
+        default: {
+          $package      = 'php7.0-ssh2'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-ssh2'
+    }
+  }
 }

--- a/manifests/extension/tidy/params.pp
+++ b/manifests/extension/tidy/params.pp
@@ -42,9 +42,27 @@
 class php::extension::tidy::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-tidy'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/tidy.ini"
   $settings = [ ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-tidy'
+          } else {
+            $package        = 'php5-tidy'
+          }
+        }
+        default: {
+          $package      = 'php7.0-tidy'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-tidy'
+    }
+  }
 }

--- a/manifests/extension/tidy/params.pp
+++ b/manifests/extension/tidy/params.pp
@@ -50,7 +50,7 @@ class php::extension::tidy::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-tidy'
           } else {
             $package        = 'php5-tidy'

--- a/manifests/extension/xcache/params.pp
+++ b/manifests/extension/xcache/params.pp
@@ -49,7 +49,7 @@ class php::extension::xcache::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-xcache'
           } else {
             $package        = 'php5-xcache'

--- a/manifests/extension/xcache/params.pp
+++ b/manifests/extension/xcache/params.pp
@@ -41,9 +41,27 @@
 class php::extension::xcache::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-xcache'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/xcache.ini"
   $settings = []
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-xcache'
+          } else {
+            $package        = 'php5-xcache'
+          }
+        }
+        default: {
+          $package      = 'php7.0-xcache'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-xcache'
+    }
+  }
 }

--- a/manifests/extension/xdebug/params.pp
+++ b/manifests/extension/xdebug/params.pp
@@ -54,7 +54,7 @@ class php::extension::xdebug::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $install_dir    = "/usr/lib/php/${::php_extension_version}"
             $package        = 'php7.0-xdebug'
           } else {

--- a/manifests/extension/xdebug/params.pp
+++ b/manifests/extension/xdebug/params.pp
@@ -44,12 +44,33 @@
 class php::extension::xdebug::params {
 
   $ensure      = $php::params::ensure
-  $package     = 'php7.0-xdebug'
   $provider    = undef
-  $install_dir = "/usr/lib/php5/${::php_extension_version}"
   $inifile     = "${php::params::config_root_ini}/xdebug.ini"
   $settings    = [
     "set .anon/zend_extension '${install_dir}/xdebug.so'"
   ]
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $install_dir    = "/usr/lib/php/${::php_extension_version}"
+            $package        = 'php7.0-xdebug'
+          } else {
+            $install_dir    = "/usr/lib/php5/${::php_extension_version}"
+            $package        = 'php5-xdebug'
+          }
+        }
+        default: {
+          $install_dir  = "/usr/lib/php/${::php_extension_version}"
+          $package      = 'php7.0-xdebug'
+        }
+      }
+    }
+    default: {
+      $install_dir  = "/usr/lib/php/${::php_extension_version}"
+      $package      = 'php7.0-xdebug'
+    }
+  }
 }

--- a/manifests/extension/yaml/params.pp
+++ b/manifests/extension/yaml/params.pp
@@ -49,7 +49,7 @@ class php::extension::yaml::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php7.0-yaml'
           } else {
             $package        = 'php5-yaml'

--- a/manifests/extension/yaml/params.pp
+++ b/manifests/extension/yaml/params.pp
@@ -41,9 +41,27 @@
 class php::extension::yaml::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php7.0-yaml'
   $provider = undef
   $inifile  = "${php::params::config_root_ini}/yaml.ini"
   $settings = []
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php7.0-yaml'
+          } else {
+            $package        = 'php5-yaml'
+          }
+        }
+        default: {
+          $package      = 'php7.0-yaml'
+        }
+      }
+    }
+    default: {
+      $package      = 'php7.0-yaml'
+    }
+  }
 }

--- a/manifests/fpm.pp
+++ b/manifests/fpm.pp
@@ -52,6 +52,7 @@ class php::fpm(
   $service_provider   = $php::fpm::params::service_provider,
 
   # settings for php-fpm.conf
+  $fpm_config                   = $php::fpm::params::fpm_config,
   $pid                          = $php::fpm::params::pid,
   $error_log                    = $php::fpm::params::error_log,
   $syslog_facility              = $php::fpm::params::syslog_facility,
@@ -66,6 +67,7 @@ class php::fpm(
   $rlimit_core                  = $php::fpm::params::rlimit_core,
   $events_mechanism             = $php::fpm::params::events_mechanism,
 
+  $config_root                  = $php::params::config_root
 ) inherits php::fpm::params {
 
   class  { 'php::fpm::package':
@@ -90,7 +92,7 @@ class php::fpm(
     require => Package[$package]
   }
 
-  file { '/etc/php/7.0/fpm/php-fpm.conf':
+  file { $fpm_config:
     notify  => Service[$service_name],
     content => template('php/fpm/php-fpm.conf.erb'),
     owner   => root,

--- a/manifests/fpm/params.pp
+++ b/manifests/fpm/params.pp
@@ -41,20 +41,15 @@
 class php::fpm::params inherits php::params {
 
   $ensure             = $::php::params::ensure
-  $package            = 'php7.0-fpm'
   $provider           = undef
-  $inifile            = '/etc/php/7.0/fpm/php.ini'
   $settings           = [ ]
 
-  $service_name       = 'php7.0-fpm'
   $service_ensure     = 'running'
   $service_enable     = true
   $service_has_status = true
   $service_provider   = undef
 
   # default params for php-fpm.conf, ported from php::fpm::daemon
-  $pid                          = '/var/run/php7.0-fpm.pid'
-  $error_log                    = '/var/log/php7.0-fpm.log'
   $syslog_facility              = undef
   $syslog_ident                 = undef
   $log_level                    = 'notice'
@@ -68,4 +63,39 @@ class php::fpm::params inherits php::params {
   $rlimit_core                  = 0
   $events_mechanism             = undef
 
-}
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $pid            = '/var/run/php7.0-fpm.pid'
+            $error_log      = '/var/log/php7.0-fpm.log'
+            $inifile        = '/etc/php/7.0/fpm/php.ini'
+            $package        = 'php7.0-fpm'
+            $service_name   = 'php7.0-fpm'
+          } else {
+            $pid            = '/var/run/php5-fpm.pid'
+            $error_log      = '/var/log/php5-fpm.log'
+            $inifile        = '/etc/php5/fpm/php.ini'
+            $package        = 'php5.0-fpm'
+            $service_name   = 'php5.0-fpm'
+          }
+        }
+        default: {
+          $pid          = '/var/run/php7.0-fpm.pid'
+          $error_log    = '/var/log/php7.0-fpm.log'
+          $inifile      = '/etc/php/7.0/fpm/php.ini'
+          $package      = 'php7.0-fpm'
+          $service_name = 'php7.0-fpm'
+        }
+      }
+    }
+    default: {
+      $pid          = '/var/run/php7.0-fpm.pid'
+      $error_log    = '/var/log/php7.0-fpm.log'
+      $inifile      = '/etc/php/7.0/fpm/php.ini'
+      $package      = 'php7.0-fpm'
+      $service_name = 'php7.0-fpm'
+    }
+  }
+} 

--- a/manifests/fpm/params.pp
+++ b/manifests/fpm/params.pp
@@ -50,6 +50,8 @@ class php::fpm::params inherits php::params {
   $service_provider   = undef
 
   # default params for php-fpm.conf, ported from php::fpm::daemon
+  $fpm_config                   = "${::php::params::config_root}/fpm/php-fpm.conf"
+  $inifile                      = "${::php::params::config_root}/fpm/php.ini"
   $syslog_facility              = undef
   $syslog_ident                 = undef
   $log_level                    = 'notice'
@@ -67,16 +69,14 @@ class php::fpm::params inherits php::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $pid            = '/var/run/php7.0-fpm.pid'
             $error_log      = '/var/log/php7.0-fpm.log'
-            $inifile        = '/etc/php/7.0/fpm/php.ini'
             $package        = 'php7.0-fpm'
             $service_name   = 'php7.0-fpm'
           } else {
             $pid            = '/var/run/php5-fpm.pid'
             $error_log      = '/var/log/php5-fpm.log'
-            $inifile        = '/etc/php5/fpm/php.ini'
             $package        = 'php5.0-fpm'
             $service_name   = 'php5.0-fpm'
           }
@@ -84,7 +84,6 @@ class php::fpm::params inherits php::params {
         default: {
           $pid          = '/var/run/php7.0-fpm.pid'
           $error_log    = '/var/log/php7.0-fpm.log'
-          $inifile      = '/etc/php/7.0/fpm/php.ini'
           $package      = 'php7.0-fpm'
           $service_name = 'php7.0-fpm'
         }

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -41,7 +41,7 @@ class php::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $config_root    = '/etc/php/7.0'
           } else {
             $config_root    = '/etc/php5'

--- a/manifests/params.pp
+++ b/manifests/params.pp
@@ -29,8 +29,6 @@ class php::params {
 
   $ensure = 'installed'
 
-  $config_root = '/etc/php'
-
   if $::php_version == '' or versioncmp($::php_version, '5.4') >= 0 {
     $config_root_ini = "${::php::params::config_root}/mods-available"
   } else {
@@ -39,4 +37,23 @@ class php::params {
 
   $augeas_contrib_dir = '/usr/share/augeas/lenses/contrib'
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $config_root    = '/etc/php/7.0'
+          } else {
+            $config_root    = '/etc/php5'
+          }
+        }
+        default: {
+          $config_root  = '/etc/php/7.0'
+        }
+      }
+    }
+    default: {  
+      $config_root  = '/etc/php/7.0'
+    }
+  }
 }

--- a/manifests/pear/params.pp
+++ b/manifests/pear/params.pp
@@ -46,7 +46,25 @@
 class php::pear::params {
 
   $ensure   = $php::params::ensure
-  $package  = 'php-pear'
   $provider = undef
 
+  case $::osfamily {
+    'Debian': {
+      case $::operatingsystem {
+        'Debian': {
+          if (versioncmp($::operatingsystemrelease, '9')) {
+            $package        = 'php-pear'
+          } else {
+            $package        = 'php-pear'
+          }
+        }
+        default: {
+          $package      = 'php-pear'
+        }
+      }
+    }
+    default: {
+      $package      = 'php-pear'
+    }
+  }
 }

--- a/manifests/pear/params.pp
+++ b/manifests/pear/params.pp
@@ -52,7 +52,7 @@ class php::pear::params {
     'Debian': {
       case $::operatingsystem {
         'Debian': {
-          if (versioncmp($::operatingsystemrelease, '9')) {
+          if (versioncmp($::operatingsystemrelease, '9') >= 0) {
             $package        = 'php-pear'
           } else {
             $package        = 'php-pear'


### PR DESCRIPTION
Changed most (if not all) hardcoded php version numbers into case statements.
This way the module will be compatible with php5 and other distro's while keeping
compatible with the new php7.0 and possible future upgrades.

** Tested package names & version numbers only for Debian Jessie and Stretch.
